### PR TITLE
Kubernetes 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,78 @@ docker-compose -f docker-compose.yml up -d
   - Проверить запуск подов reddit-приложения можно командой
 
         kubectl get pods
+
+# ДЗ-20 "Kubernetes. Запуск кластера и приложения. Модель безопасности"
+
+## В процессе сделано:
+
+  - Reddit-приложение развернуто в локальном K8s кластере `minikube` в отдельном нэймспэйсе `dev`.
+
+    - По 3 реплики(пода) на каждый сервис: ui, comment, post.
+    - 1 реплика MongoDB с персистентным хранилищем.
+    - Созданы k8s-сервисы для взаимодействия между компонентами и БД
+    - Создан сервис типа NodePort для доступа к веб-интерфейсу всего приложения извне.
+
+  - Создан GKE-кластер вручную.
+
+  - Reddit-приложение развернуто в GKE k8s кластере.
+    Шаги для запуска см. в [KUBERNETES.md](./kubernetes/KUBERNETES.md)
+
+  - (⭐) Создан GKE-кластер с помощью [Terraform](./kubernetes/terraform)
+
+  - (⭐) Настроено использование dashboard addon'а для кластера.
+    Шаги по настройке см. в [DASHBOARD.md](./kubernetes/dashboard/DASHBOARD.md)
+
+    _Примечание: при использовании дашборда на минимальных инстансах не хватает CPU для размещения pod'ов приложения._
+
+## Как запустить проект:
+
+  - Создать k8s кластер
+
+     - локальный
+
+           minikube start
+
+     - или в GKE с помощью Terrafrom.
+       См [KUBERNETES.md](./kubernetes/KUBERNETES.md)
+
+           cd ./kubernetes/terraform
+           terraform init
+           terraform plan
+           terraforn apply
+
+  - Создать нэймспэйс
+
+        kubectl apply -f ./kubernetes/reddit/dev-namespace.yml
+
+  - Применить деплойменты и сервисы для приложения
+
+        kubectl apply -f ./kubernetes/reddit/.
+
+  - Включить dashboard addon для кластера в GKE и настроить его использование.
+    См. [DASHBOARD.md](./kubernetes/dashboard/DASHBOARD.md)
+    Запустить проксирование дашборда на локалхост
+
+        kubectl proxy
+
+## Как проверить работоспособность:
+
+  - Проверить текущий K8s контекст
+
+        kubectl config current-context
+
+  - Проверить наличие и состояние ресурсов приложения
+
+        kubectl get all -n dev
+
+  - Приложение должно быть доступно по `http://<node_ip>:<node_port>` ,
+    где `node_ip` можно получить из вывода команды
+
+        kubectl get nodes -o wide
+
+    а `nodeport` - из вывода команды
+
+        kubectl describe service ui -n dev | grep NodePort
+
+  - K8s дашборд должен быть доступен по
+    http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/

--- a/kubernetes/KUBERNETES.md
+++ b/kubernetes/KUBERNETES.md
@@ -1,0 +1,24 @@
+# How to run Kubernetes in GCP
+
+_Requires Google provider v3.0.0+ for Terraform!_
+
+- Use [Terraform](./terraform) project to create K8s cluster in GKE
+  and add firewall rules for nodeports
+
+      cd ./terraform
+      terraform init
+      terraform apply
+
+- Connect to K8s cluster (grab it from `terraform output`)
+
+      gcloud container clusters get-credentials cluster-2 --zone europe-west1-b --project docker-276915
+
+- Create `dev` namepspace
+
+      kubectl apply -f ./reddit/dev-namespace.yml
+
+- Create K8s resources for reddit app
+
+      kubectl apply -f ./reddit/
+
+- To enable K8s cluster dashboard follow instruction in [DASHBOARD.md](./dashboard/DASHBOARD.md)

--- a/kubernetes/dashboard/DASHBOARD.md
+++ b/kubernetes/dashboard/DASHBOARD.md
@@ -1,0 +1,20 @@
+# Kubernetes Dashboard in GKE
+
+_According to [this](https://github.com/kubernetes/dashboard/blob/master/docs/user/access-control/creating-sample-user.md):_
+
+  - Enable the dashboard addon in GKE
+  - Create a service account and bind `cluster-admin` role to it
+
+        kubectl apply -f .
+
+  - Get a Bearer Token from output of
+
+        kubectl -n kube-system describe secret \
+            $(kubectl -n kube-system get secret | grep admin-user | awk '{print $1}')
+
+  - Start proxying a dashbord to localhost:
+
+        kubectl proxy
+
+  - Go to the URL below and authenticate with the token
+    http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/

--- a/kubernetes/dashboard/dashboard-adminuser.yml
+++ b/kubernetes/dashboard/dashboard-adminuser.yml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kube-system

--- a/kubernetes/dashboard/dashboard-clusterrolebinding.yml
+++ b/kubernetes/dashboard/dashboard-clusterrolebinding.yml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: admin-user
+    namespace: kube-system

--- a/kubernetes/reddit/comment-deployment.yml
+++ b/kubernetes/reddit/comment-deployment.yml
@@ -1,19 +1,27 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: comment-deployment
+  name: comment
+  labels:
+    app: reddit
+    component: comment
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: comment
+      app: reddit
+      component: comment
   template:
     metadata:
       name: comment
       labels:
-        app: comment
+        app: reddit
+        component: comment
     spec:
       containers:
-        - image: nikitagsh/comment
-          name: comment
+      - image: nikitagsh/comment
+        name: comment
+        env:
+        - name: COMMENT_DATABASE_HOST
+          value: comment-db

--- a/kubernetes/reddit/comment-mongodb-service.yml
+++ b/kubernetes/reddit/comment-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment-db
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    comment-db: "true"

--- a/kubernetes/reddit/comment-service.yml
+++ b/kubernetes/reddit/comment-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: comment
+  labels:
+    app: reddit
+    component: comment
+spec:
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: comment

--- a/kubernetes/reddit/dev-namespace.yml
+++ b/kubernetes/reddit/dev-namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dev

--- a/kubernetes/reddit/mongo-deployment.yml
+++ b/kubernetes/reddit/mongo-deployment.yml
@@ -1,19 +1,34 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: mongo-deployment
+  name: mongo
+  labels:
+    app: reddit
+    component: mongo
+    comment-db: "true"
+    post-db: "true"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: mongo
+      app: reddit
+      component: mongo
   template:
     metadata:
       name: mongo
       labels:
-        app: mongo
+        app: reddit
+        component: mongo
+        comment-db: "true"
+        post-db: "true"
     spec:
       containers:
-        - image: mongo:3.2
-          name: mongo
+      - image: mongo:3.2
+        name: mongo
+        volumeMounts:
+        - name: mongo-persistent-storage
+          mountPath: /data/db
+      volumes:
+      - name: mongo-persistent-storage
+        emptyDir: {}

--- a/kubernetes/reddit/mongodb-service.yml
+++ b/kubernetes/reddit/mongodb-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongodb
+  labels:
+    app: reddit
+    component: mongo
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo

--- a/kubernetes/reddit/post-deployment.yml
+++ b/kubernetes/reddit/post-deployment.yml
@@ -1,19 +1,27 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: post-deployment
+  name: post
+  labels:
+    app: reddit
+    component: post
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: post
+      app: reddit
+      component: post
   template:
     metadata:
       name: post
       labels:
-        app: post
+        app: reddit
+        component: post
     spec:
       containers:
-        - image: nikitagsh/post
-          name: post
+      - image: nikitagsh/post
+        name: post
+        env:
+        - name: POST_DATABASE_HOST
+          value: post-db

--- a/kubernetes/reddit/post-mongodb-service.yml
+++ b/kubernetes/reddit/post-mongodb-service.yml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post-db
+  labels:
+    app: reddit
+    component: mongo
+    post-db: "true"
+spec:
+  ports:
+    - port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    app: reddit
+    component: mongo
+    post-db: "true"

--- a/kubernetes/reddit/post-service.yml
+++ b/kubernetes/reddit/post-service.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: post
+  labels:
+    app: reddit
+    component: post
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    targetPort: 5000
+  selector:
+    app: reddit
+    component: post

--- a/kubernetes/reddit/ui-deployment.yml
+++ b/kubernetes/reddit/ui-deployment.yml
@@ -1,19 +1,29 @@
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ui-deployment
+  name: ui
+  labels:
+    app: reddit
+    component: ui
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
-      app: ui
+      app: reddit
+      component: ui
   template:
     metadata:
-      name: ui
+      name: ui-pod
       labels:
-        app: ui
+        app: reddit
+        component: ui
     spec:
       containers:
         - image: nikitagsh/ui
           name: ui
+          env:
+          - name: ENV
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace

--- a/kubernetes/reddit/ui-service.yml
+++ b/kubernetes/reddit/ui-service.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    app: reddit
+    component: ui
+spec:
+  type: NodePort
+  ports:
+  - port: 9292
+    protocol: TCP
+    targetPort: 9292
+  selector:
+    app: reddit
+    component: ui

--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -1,0 +1,60 @@
+//---------------------------------------------------------------------- terraform / backend
+terraform {
+  required_version = "~>0.12.0"
+}
+//---------------------------------------------------------------------- provider
+provider "google" {
+  version = "~>3.0.0"
+  project = var.project
+  region  = var.region
+}
+//---------------------------------------------------------------------- firewall rules for kubernetes nodeports
+resource "google_compute_firewall" "kubernetes-nodeports" {
+  name    = "kubernetes-nodeports-default"
+  network = "default"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["30000-32767"]
+  }
+}
+//---------------------------------------------------------------------- kubernetes cluster
+resource "google_container_cluster" "kubernetes-cluster" {
+  name               = "cluster-2"
+  location           = var.zone != "" ? var.zone : var.region
+  network            = "default"
+  initial_node_count = var.node_count
+
+  master_auth {
+    //// Basic authentication is disabled
+    // username = ""
+    // password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  node_config {
+    machine_type = var.machine_type
+    disk_size_gb = var.node_disk_size_gb
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/trace.append"
+    ]
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+}

--- a/kubernetes/terraform/outputs.tf
+++ b/kubernetes/terraform/outputs.tf
@@ -1,0 +1,8 @@
+output "kubernetes-cluster-connection" {
+  value = join("", [
+    "gcloud container clusters get-credentials ",
+    google_container_cluster.kubernetes-cluster.name,
+    " --zone ", var.zone,
+    " --project ", var.project
+  ])
+}

--- a/kubernetes/terraform/terraform.tfvars.example
+++ b/kubernetes/terraform/terraform.tfvars.example
@@ -1,0 +1,6 @@
+project           = "docker-276915"
+node_disk_size_gb = "20"
+machine_type      = "g1-small"
+region            = "europe-west1"
+zone              = "europe-west1-b"
+node_count        = "2"

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -1,0 +1,28 @@
+variable project {
+  description = "Project ID"
+}
+
+variable region {
+  description = "Region"
+  default     = "europe-west1"
+}
+
+variable zone {
+  description = "Zone"
+  default     = "europe-west1-b"
+}
+
+variable node_count {
+  description = "Number of cluster nodes"
+  default     = "2"
+}
+
+variable node_disk_size_gb {
+  description = "Node disk size"
+  default     = "100"
+}
+
+variable machine_type {
+  description = "Node machine type"
+  default     = "n1-standard-1"
+}


### PR DESCRIPTION
# Выполнено ДЗ № 20 "Kubernetes. Запуск кластера и приложения. Модель безопасности"

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:

  - Reddit-приложение развернуто в локальном K8s кластере `minikube` в отдельном нэймспэйсе `dev`.

    - По 3 реплики(пода) на каждый сервис: ui, comment, post.
    - 1 реплика MongoDB с персистентным хранилищем.
    - Созданы k8s-сервисы для взаимодействия между компонентами и БД
    - Создан сервис типа NodePort для доступа к веб-интерфейсу всего приложения извне.

  - Создан GKE-кластер вручную.

  - Reddit-приложение развернуто в GKE k8s кластере.
    Шаги для запуска см. в [KUBERNETES.md](./kubernetes/KUBERNETES.md)

  - (⭐) Создан GKE-кластер с помощью [Terraform](./kubernetes/terraform)

  - (⭐) Настроено использование dashboard addon'а для кластера.
    Шаги по настройке см. в [DASHBOARD.md](./kubernetes/dashboard/DASHBOARD.md)

    _Примечание: при использовании дашборда на минимальных инстансах не хватает CPU для размещения pod'ов приложения._

## Как запустить проект:
  - Создать k8s кластер

     - локальный

           minikube start

     - или в GKE с помощью Terrafrom.
       См [KUBERNETES.md](./kubernetes/KUBERNETES.md)

           cd ./kubernetes/terraform
           terraform init
           terraform plan
           terraforn apply

  - Создать нэймспэйс

        kubectl apply -f ./kubernetes/reddit/dev-namespace.yml

  - Применить деплойменты и сервисы для приложения

        kubectl apply -f ./kubernetes/reddit/.

  - Включить dashboard addon для кластера в GKE и настроить его использование.
    См. [DASHBOARD.md](./kubernetes/dashboard/DASHBOARD.md)
    Запустить проксирование дашборда на локалхост

        kubectl proxy

## Как проверить работоспособность:
  - **Приложение в GKE доступно тут http://35.189.200.165:32449/**

  - Проверить текущий K8s контекст

        kubectl config current-context

  - Проверить наличие и состояние ресурсов приложения

        kubectl get all -n dev

  - Приложение должно быть доступно по `http://<node_ip>:<node_port>` ,
    где `node_ip` можно получить из вывода команды

        kubectl get nodes -o wide

    а `nodeport` - из вывода команды

        kubectl describe service ui -n dev | grep NodePort

  - K8s дашборд должен быть доступен по
    http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/

## PR checklist
 - [x] Выставил label с номером домашнего задания
 - [x] Выставил label с темой домашнего задания
